### PR TITLE
small check to allow scenario with many providers pre-configured but enabled only defined in a JSON file

### DIFF
--- a/Quick.Logger.pas
+++ b/Quick.Logger.pas
@@ -1709,7 +1709,8 @@ begin
       for iprovider in Self do
       begin
         jvalue := jobject.GetValue(iprovider.GetName);
-        iprovider.FromJson(jvalue.ToJSON);
+        if Assigned(jvalue) then
+          iprovider.FromJson(jvalue.ToJSON);
       end;
     finally
       jobject.Free;


### PR DESCRIPTION
Hi - it's a small check, and pls include it. This simplifies a JSON config file to be smaller only with used providers chosen by the end-user. Without this, JSON would have to contain sections for not used providers with one key "Enabled": false