### PR TITLE
Fix Sentry DSN parsing when using custom port on the server.

### DIFF
--- a/Quick.Logger.Provider.Sentry.pas
+++ b/Quick.Logger.Provider.Sentry.pas
@@ -258,12 +258,12 @@ procedure TLogSentryProvider.SetDSNEntry(const Value: string);
 var
   segments : TArray<string>;
 begin
-  segments := value.Split(['/',':','@']);
+  segments := value.Split(['/','@']);
   try
-    fProtocol := segments[0];
-    fPublicKey := segments[3];
-    fSentryHost := segments[4];
-    fProjectId := segments[5];
+    fProtocol := segments[0].Replace(':','');
+    fPublicKey := segments[2];
+    fSentryHost := segments[3];
+    fProjectId := segments[4];
   except
     raise Exception.Create('Sentry DSN not valid!');
   end;


### PR DESCRIPTION
This should fix the Sentry DSN parsing when using custom server ports like:
"http://publickey@sentry.server.com:9000/47"

In the current implementation, the segment indexes would be incorrect after splitting a string with multiple ":" occurrences.