### PR TITLE
Attempted to fix random AV on application close

### DIFF
--- a/Quick.Logger.pas
+++ b/Quick.Logger.pas
@@ -1096,9 +1096,9 @@ var
 begin
   //call interface provider to writelog
   fProvider.SetStatus(psRunning);
-  while (not Terminated) or (fLogQueue.QueueSize > 0) do
+  while (not Terminated) or (Assigned(fLogQueue) and (fLogQueue.QueueSize > 0)) do
   begin
-    if fLogQueue.PopItem(qSize,logitem) = TWaitResult.wrSignaled then
+    if Assigned(fLogQueue) and (fLogQueue.PopItem(qSize,logitem) = TWaitResult.wrSignaled) then
     begin
       {$IFDEF LOGGER_DEBUG2}
       Writeln(Format('popitem logger: %s',[logitem.Msg]));


### PR DESCRIPTION
Random access violation occurs when closing application. I think it is a race condition when fLogQueue is freed and TThreadProviderLog is still executing. Just added a check to prevent such case.