### PR TITLE
fix clone TLogExceptionItem StackTrace missing

### DIFF
--- a/Quick.Logger.pas
+++ b/Quick.Logger.pas
@@ -1267,6 +1267,7 @@ begin
   Result.EventDate := Self.EventDate;
   Result.Msg := Self.Msg;
   TLogExceptionItem(Result).Exception := Self.Exception;
+  TLogExceptionItem(Result).StackTrace := Self.StackTrace;
 end;
 
 


### PR DESCRIPTION
The value of StackTrace has not clone in the clone function of the type TLogExceptionItem. 
Thus the providers don't send it to WriteLog function.
