### PR TITLE
Added nil check to avoid AV

### DIFF
--- a/Quick.Logger.pas
+++ b/Quick.Logger.pas
@@ -1431,6 +1431,11 @@ begin
   {$ELSE}
   cLogItem.ThreadId := TThread.CurrentThread.ThreadID;
   {$ENDIF}
+  if not Assigned(Self) then
+  begin
+    FreeAndNil(cLogItem);
+    Exit;
+  end;
   if fLogQueue.PushItem(cLogItem) <> TWaitResult.wrSignaled then
   begin
     FreeAndNil(cLogItem);


### PR DESCRIPTION
Fixed an access violation that occurs when the application shuts down while a TLogger instance is still enqueuing logs.